### PR TITLE
[Feature] 주문 생성 API 개발

### DIFF
--- a/src/main/java/com/example/auction/common/entity/BaseCreateTimeEntity.java
+++ b/src/main/java/com/example/auction/common/entity/BaseCreateTimeEntity.java
@@ -1,0 +1,23 @@
+package com.example.auction.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseCreateTimeEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createAt;
+
+}

--- a/src/main/java/com/example/auction/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/auction/domain/order/controller/OrderController.java
@@ -1,0 +1,37 @@
+package com.example.auction.domain.order.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.example.auction.common.response.CommonResponse;
+import com.example.auction.domain.auth.security.CustomUserDetails;
+import com.example.auction.domain.order.dto.request.OrderRequestDto;
+import com.example.auction.domain.order.dto.response.OrderResponseDto;
+import com.example.auction.domain.order.service.OrderService;
+import com.example.auction.domain.user.entity.User;
+
+@RequestMapping("/api/orders")
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+
+	private final OrderService orderService;
+
+	@PostMapping
+	public CommonResponse<OrderResponseDto> orderSave(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		OrderRequestDto requestDto) {
+
+		User loginUser = userDetails.getUser();
+		Long totalPrice = requestDto.totalPrice();
+		Long productId = requestDto.productId();
+
+		OrderResponseDto responseDto = orderService.orderSave(loginUser, totalPrice, productId);
+
+		return CommonResponse.created(responseDto);
+	}
+
+}

--- a/src/main/java/com/example/auction/domain/order/dto/request/OrderRequestDto.java
+++ b/src/main/java/com/example/auction/domain/order/dto/request/OrderRequestDto.java
@@ -1,0 +1,7 @@
+package com.example.auction.domain.order.dto.request;
+
+public record OrderRequestDto(
+	Long productId,
+	Long totalPrice
+) {
+}

--- a/src/main/java/com/example/auction/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/example/auction/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.auction.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+import com.example.auction.domain.order.entity.Order;
+import com.example.auction.domain.product.entity.Product;
+import com.example.auction.domain.user.entity.User;
+
+@Builder
+public record OrderResponseDto(
+	Long orderId,
+	Long userId,
+	String productName,
+	Long totalPrice,
+	LocalDateTime createdAt
+) {
+
+	public static OrderResponseDto from(Order order, User user, Product product) {
+		return OrderResponseDto.builder()
+			.orderId(order.getId())
+			.userId(user.getId())
+			.productName(product.getName())
+			.totalPrice(order.getTotalPrice())
+			.createdAt(order.getCreateAt())
+			.build();
+	}
+}

--- a/src/main/java/com/example/auction/domain/order/entity/Order.java
+++ b/src/main/java/com/example/auction/domain/order/entity/Order.java
@@ -1,48 +1,49 @@
 package com.example.auction.domain.order.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.example.auction.common.entity.BaseCreateTimeEntity;
+import com.example.auction.domain.user.entity.User;
+
 @Table(name = "orders")
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Order extends BaseCreateTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private Long userId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", unique = true, nullable = false)
+	private User user;
 
-	private int totalPrice;
+	@Column(nullable = false)
+	private long totalPrice;
 
+	@Column(nullable = false)
 	private OrderStatus orderStatus;
 
-	// 내부에서만 사용하는 생성자
-	@Builder
-	private Order(Long userId, int totalPrice, OrderStatus orderStatus) {
-		this.userId = userId;
-		this.totalPrice = totalPrice;
-		this.orderStatus = orderStatus;
-
-	}
-
-	/**
-	 * 정적
-	 *
-	 */
-	public static Order of(Long userId, int totalPrice) {
+	public static Order of(User user, long totalPrice) {
 		return Order.builder()
-			.userId(userId)
+			.user(user)
 			.totalPrice(totalPrice)
 			.orderStatus(OrderStatus.NON_ORDER)
 			.build();

--- a/src/main/java/com/example/auction/domain/order/entity/Order.java
+++ b/src/main/java/com/example/auction/domain/order/entity/Order.java
@@ -32,7 +32,7 @@ public class Order extends BaseCreateTimeEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", unique = true, nullable = false)
+	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@Column(nullable = false)

--- a/src/main/java/com/example/auction/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/auction/domain/order/entity/OrderItem.java
@@ -1,6 +1,5 @@
 package com.example.auction.domain.order.entity;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,62 +7,40 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.example.auction.domain.product.entity.Product;
+
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderItem {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// 어떤 주문에 속하는지
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "order_id", nullable = false)
+	@JoinColumn(name = "orders_id", nullable = false)
 	private Order order;
 
-	// 어떤 상품인지
-	@Column(nullable = false)
-	private Long productId;
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "orders_id", nullable = false)
+	private Product product;
 
-	// 수량
-	@Column(nullable = false)
-	private int quantity = 1;
-
-	// 단가
-	@Column(nullable = false)
-	private int price;
-
-	@Builder
-	private OrderItem(Order order, Long productId, int quantity, int price) {
-		this.order = order;
-		this.productId = productId;
-		this.quantity = quantity;
-		this.price = price;
-	}
-
-	/**
-	 * 정적 팩토리 메서드로 생성 (기본 수량 1)
-	 */
-	public static OrderItem of(Order order, Long productId, int price) {
+	public static OrderItem of(Order order, Product product) {
 		return OrderItem.builder()
 			.order(order)
-			.productId(productId)
-			.quantity(1)
-			.price(price)
+			.product(product)
 			.build();
 	}
 
-	/**
-	 * 금액 계산
-	 */
-	public int getTotalPrice() {
-		return this.price * this.quantity;
-	}
 }

--- a/src/main/java/com/example/auction/domain/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/example/auction/domain/order/exception/OrderErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.auction.domain.order.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import com.example.auction.common.exception.BaseCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderErrorCode implements BaseCode {
+
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O001", "주문한 상품이 없습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/example/auction/domain/order/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/auction/domain/order/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.auction.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.auction.domain.order.entity.OrderItem;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}

--- a/src/main/java/com/example/auction/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/auction/domain/order/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.example.auction.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.auction.domain.order.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/com/example/auction/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/auction/domain/order/service/OrderService.java
@@ -1,0 +1,48 @@
+package com.example.auction.domain.order.service;
+
+import static com.example.auction.domain.product.exception.ProductErrorCode.PRODUCT_NOT_FOUND;
+import static com.example.auction.domain.user.exception.ErrorCode.NOT_FOUND_USER;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.auction.common.exception.CustomException;
+import com.example.auction.domain.order.dto.response.OrderResponseDto;
+import com.example.auction.domain.order.entity.Order;
+import com.example.auction.domain.order.entity.OrderItem;
+import com.example.auction.domain.order.repository.OrderItemRepository;
+import com.example.auction.domain.order.repository.OrderRepository;
+import com.example.auction.domain.product.entity.Product;
+import com.example.auction.domain.product.repository.ProductRepository;
+import com.example.auction.domain.user.entity.User;
+import com.example.auction.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+
+	private final OrderRepository orderRepository;
+	private final OrderItemRepository orderItemRepository;
+	private final ProductRepository productRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	@PreAuthorize("hasRole('ADMIN')")
+	public OrderResponseDto orderSave(User loginUser, Long totalPrice, Long productId) {
+
+		User findUser = userRepository.findById(loginUser.getId())
+			.orElseThrow(() -> new CustomException(NOT_FOUND_USER, NOT_FOUND_USER.getMessage()));
+
+		Product findProduct = productRepository.findById(productId)
+			.orElseThrow(() -> new CustomException(PRODUCT_NOT_FOUND, PRODUCT_NOT_FOUND.getMessage()));
+
+		Order saveOrder = orderRepository.save(Order.of(findUser, totalPrice));
+		orderItemRepository.save(OrderItem.of(saveOrder, findProduct));
+
+		return OrderResponseDto.from(saveOrder, findUser, findProduct);
+	}
+}

--- a/src/main/java/com/example/auction/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/auction/domain/order/service/OrderService.java
@@ -31,7 +31,7 @@ public class OrderService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	@PreAuthorize("hasRole('ADMIN')")
+	@PreAuthorize("hasRole('USER')")
 	public OrderResponseDto orderSave(User loginUser, Long totalPrice, Long productId) {
 
 		User findUser = userRepository.findById(loginUser.getId())

--- a/src/main/java/com/example/auction/domain/product/exception/ProductErrorCode.java
+++ b/src/main/java/com/example/auction/domain/product/exception/ProductErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.auction.domain.product.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import com.example.auction.common.exception.BaseCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductErrorCode implements BaseCode {
+
+	PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "요청하신 상품을 찾을 수 없습니다."),
+
+	;
+
+	private final HttpStatus httpStatus;
+	private final String code;
+	private final String message;
+
+}

--- a/src/main/java/com/example/auction/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/auction/domain/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.example.auction.domain.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.example.auction.domain.product.entity.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #9



## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 주문 생성 API 개발 |
| 🔍 목적 | 경매 상품이 낙찰이 되면 해당 api가 호출이 되어 주문이 생성됩니다. |
| 🛠️ 변경사항 | API 개발 |



## 📝 상세 내역
| 번호 | 내용 |
|------|------|
| 1️⃣ | 주문 생성 API 개발에 관련한 order 패키지 계층 코드 수정 |
| 2️⃣ | 생성일(createdAt) 필드만 가지고 있는 BaseCreateTimeEntity 추상 클래스 작성 |
| 3️⃣ | Order, OrderEntity에 미적용된 연관관계 매핑 적용 추가 및 정적 팩토리 메서드 추가|
| 4️⃣ | 다른 Entity와 Entity 구조를 맞추기 위해 @Builder를 클래스 레벨에 적용 및 롬복 사용 후 명시적으로 작성한 생성자 제거 |


---

## 🙋‍♀️ 리뷰어 참고사항
- 주문 생성 API를 자동으로 호출하는 구조 낙찰 API 개발 후 진행 되거나 직접 버튼을 누르는 방식으로 논의가 필요할 것 같습니다.
- 테스트 코드는 별도의 PR로 진행될 예정이며 테스트 코드 PR에 postman 테스트 스크린샷도 함께 추가 될 예정입니다.
