### PR TITLE
FIX : 입찰내역이 없는 경매일경우 에러 생성

### DIFF
--- a/src/main/java/com/example/auction/config/RedisConfig.java
+++ b/src/main/java/com/example/auction/config/RedisConfig.java
@@ -38,19 +38,10 @@ public class RedisConfig {
 		// Redis용 ObjectMapper 설정
 		ObjectMapper redisObjectMapper = createRedisObjectMapper();
 
-		// 직렬화 설정
-		GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
-		StringRedisSerializer stringSerializer = new StringRedisSerializer();
-
-		template.setKeySerializer(stringSerializer);
-		template.setHashKeySerializer(stringSerializer);
-		template.setValueSerializer(jsonSerializer);
-		template.setHashValueSerializer(jsonSerializer);
-
 		template.setKeySerializer(new StringRedisSerializer());
-		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper));
 		template.setHashKeySerializer(new StringRedisSerializer());
-		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(redisObjectMapper));
 		template.setEnableTransactionSupport(true);
 		template.afterPropertiesSet();
 

--- a/src/main/java/com/example/auction/domain/auctionbid/exception/AuctionBidErrorCode.java
+++ b/src/main/java/com/example/auction/domain/auctionbid/exception/AuctionBidErrorCode.java
@@ -1,18 +1,20 @@
 package com.example.auction.domain.auctionbid.exception;
 
-import com.example.auction.common.exception.BaseCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
+
+import com.example.auction.common.exception.BaseCode;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuctionBidErrorCode implements BaseCode {
 
-	NOT_FOUND_Bid(HttpStatus.CONFLICT, "D001", "요청하신 로그를 찾을 수 없습니다."),
-	BID_PRICE_BELOW_START(HttpStatus.BAD_REQUEST, "B001", "입찰 금액은 시작가보다 높아야 합니다."),
-	BID_PRICE_BELOW_HIGHEST(HttpStatus.BAD_REQUEST, "B002", "입찰 금액은 현재 최고가보다 높아야 합니다."),
-	;
+	NOT_FOUND_BID(HttpStatus.CONFLICT, "B001", "요청하신 로그를 찾을 수 없습니다."),
+	BID_PRICE_BELOW_START(HttpStatus.BAD_REQUEST, "B002", "입찰 금액은 시작가보다 높아야 합니다."),
+	BID_PRICE_BELOW_HIGHEST(HttpStatus.BAD_REQUEST, "B003", "입찰 금액은 현재 최고가보다 높아야 합니다."),
+	REDIS_LOGS_NOT_FOUND(HttpStatus.NOT_FOUND, "B004", "입찰내역이 없는 경매입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/auction/domain/auctionbid/handler/AuctionBidKeyEventHandler.java
+++ b/src/main/java/com/example/auction/domain/auctionbid/handler/AuctionBidKeyEventHandler.java
@@ -2,11 +2,22 @@ package com.example.auction.domain.auctionbid.handler;
 
 import static com.example.auction.domain.user.exception.ErrorCode.NOT_FOUND_USER;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Component;
+
 import com.example.auction.common.exception.CustomException;
 import com.example.auction.common.exception.ErrorCode;
 import com.example.auction.common.handler.RedisKeyEventHandler;
 import com.example.auction.common.service.RedisService;
 import com.example.auction.domain.auctionbid.dto.BidRedisDto;
+import com.example.auction.domain.auctionbid.exception.AuctionBidErrorCode;
 import com.example.auction.domain.product.service.ProductService;
 import com.example.auction.domain.test.repository.AuctionBidJdbcRepository;
 import com.example.auction.domain.user.entity.User;
@@ -16,76 +27,73 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class AuctionBidKeyEventHandler implements RedisKeyEventHandler {
 
-    private final RedisService redisService;
-    private final ProductService productService;
-    private final AuctionBidJdbcRepository auctionBidJdbcRepository;
-    private final UserRepository userRepository;
+	private final RedisService redisService;
+	private final ProductService productService;
+	private final AuctionBidJdbcRepository auctionBidJdbcRepository;
+	private final UserRepository userRepository;
 
-    @Override
-    public String getPrefix() {
-        return "auction:end";
-    }
+	@Override
+	public String getPrefix() {
+		return "auction:end";
+	}
 
-    //redis 데이터 세팅에 따라 수정 예정
-    @Override
-    public void handle(String key) {
+	//redis 데이터 세팅에 따라 수정 예정
+	@Override
+	public void handle(String key) {
 
-        String productId = key.split("auction:end:")[1];
+		String productId = key.split("auction:end:")[1];
 
-        String getLogs = "auction:" + productId + ":logs";
-        String getHighest = "auction:" + productId + ":highest";
+		String getLogs = "auction:" + productId + ":logs";
+		String getHighest = "auction:" + productId + ":highest";
 
-        setBatchInsert(getLogs);
-        setFinalPrice(getHighest);
-    }
-    public void setBatchInsert(String key){
-        Set<TypedTuple<Object>> tuples = redisService.getZSetReversData(key);
-        List<String> jsonList = tuples.stream().map(data -> (String) data.getValue()).toList();
-        List<BidRedisDto> dtoList = jsonList.stream().map(json -> {
-            try {
-                return setObjectMapper().readValue(json, BidRedisDto.class);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
-        }).toList();
-        auctionBidJdbcRepository.batchInsert(dtoList);
-        redisService.deleteRedisTemplateKeyValue(key);
-    }
+		setBatchInsert(getLogs);
+		setFinalPrice(getHighest);
+	}
 
-    public void setFinalPrice(String key){
-        String json = redisService.getKeyValueAsString(key);
-        BidRedisDto dto;
-        try {
-            dto = setObjectMapper().readValue(json, BidRedisDto.class);
-        } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.REDIS_DESERIALIZATION_ERROR);
-        }
-        User user = userRepository.findById(dto.getUserId()).orElseThrow(()-> new CustomException(NOT_FOUND_USER));
-        productService.updateFinalPrice(dto.getProductId(),dto.getBidPrice(),user);
-        redisService.deleteStringRedisTemplateKeyValue(key);
+	public void setBatchInsert(String key) {
+		Set<TypedTuple<Object>> tuples = redisService.getZSetReversData(key);
+		if (tuples == null || tuples.isEmpty()) {
+			throw new CustomException(AuctionBidErrorCode.REDIS_LOGS_NOT_FOUND);
+		}
+		List<String> jsonList = tuples.stream().map(data -> (String)data.getValue()).toList();
+		List<BidRedisDto> dtoList = jsonList.stream().map(json -> {
+			try {
+				return setObjectMapper().readValue(json, BidRedisDto.class);
+			} catch (JsonProcessingException e) {
+				throw new RuntimeException(e);
+			}
+		}).toList();
+		auctionBidJdbcRepository.batchInsert(dtoList);
+		redisService.deleteRedisTemplateKeyValue(key);
+	}
 
-    }
+	public void setFinalPrice(String key) {
+		String json = redisService.getKeyValueAsString(key);
+		BidRedisDto dto;
+		try {
+			dto = setObjectMapper().readValue(json, BidRedisDto.class);
+		} catch (JsonProcessingException e) {
+			throw new CustomException(ErrorCode.REDIS_DESERIALIZATION_ERROR);
+		}
+		User user = userRepository.findById(dto.getUserId()).orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+		productService.updateFinalPrice(dto.getProductId(), dto.getBidPrice(), user);
+		redisService.deleteStringRedisTemplateKeyValue(key);
 
-    public ObjectMapper setObjectMapper(){
-        ObjectMapper objectMapper = new ObjectMapper();
-        JavaTimeModule javaTimeModule = new JavaTimeModule();
-        javaTimeModule.addDeserializer(LocalDateTime.class,
-            new LocalDateTimeDeserializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-        objectMapper.registerModule(javaTimeModule);
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        return objectMapper;
-    }
+	}
+
+	public ObjectMapper setObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		JavaTimeModule javaTimeModule = new JavaTimeModule();
+		javaTimeModule.addDeserializer(LocalDateTime.class,
+			new LocalDateTimeDeserializer(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+		objectMapper.registerModule(javaTimeModule);
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return objectMapper;
+	}
 
 }

--- a/src/main/java/com/example/auction/domain/auctionbid/service/AuctionBidService.java
+++ b/src/main/java/com/example/auction/domain/auctionbid/service/AuctionBidService.java
@@ -1,9 +1,8 @@
 package com.example.auction.domain.auctionbid.service;
 
 import static com.example.auction.domain.auctionbid.exception.AuctionBidErrorCode.BID_PRICE_BELOW_START;
-import static com.example.auction.domain.auctionbid.exception.AuctionBidErrorCode.NOT_FOUND_Bid;
+import static com.example.auction.domain.auctionbid.exception.AuctionBidErrorCode.NOT_FOUND_BID;
 
-import com.example.auction.domain.auctionbid.entity.AuctionBid;
 import java.time.LocalDateTime;
 
 import lombok.RequiredArgsConstructor;
@@ -11,13 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import com.example.auction.common.exception.CustomException;
-import com.example.auction.common.exception.ErrorCode;
 import com.example.auction.domain.auctionbid.dto.BidRedisDto;
 import com.example.auction.domain.auctionbid.dto.request.BidRequestDto;
+import com.example.auction.domain.auctionbid.entity.AuctionBid;
 import com.example.auction.domain.auctionbid.repository.AuctionBidRepository;
 import com.example.auction.domain.product.entity.Product;
 import com.example.auction.domain.product.repository.ProductRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -42,9 +40,9 @@ public class AuctionBidService {
 		auctionBidRedisService.trySaveHighestBid(productId, dto);
 	}
 
-	public void update(Long productId,Long finalPrice){
-		AuctionBid auctionBid =  auctionBidRepository.findByProductIdAndBidPrice(productId, finalPrice)
-			.orElseThrow(()->new CustomException(NOT_FOUND_Bid));
+	public void update(Long productId, Long finalPrice) {
+		AuctionBid auctionBid = auctionBidRepository.findByProductIdAndBidPrice(productId, finalPrice)
+			.orElseThrow(() -> new CustomException(NOT_FOUND_BID));
 		auctionBid.isSuccessUpdate();
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #42 



## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 기능명 | 에러|
| 🔍 목적 | 상품생성하고 입찰내역이 하나도 없을때 에러를 던져서 최고가 산정안하게하려고|
| 🛠️ 변경사항 | 입찰내역 == null 일때 throw customexception |


